### PR TITLE
Speed up containsTimestamp

### DIFF
--- a/timestamp.go
+++ b/timestamp.go
@@ -9,7 +9,8 @@ func containsTimestamp(line string) bool {
 		line = line[:lookForTimestampLimit]
 	}
 	var digits, colons int
-	for _, r := range line {
+	for i := 0; i < len(line); i++ {
+		r := line[i]
 		switch {
 		case r >= '0' && r <= '9':
 			digits++


### PR DESCRIPTION
Iterate over string bytes instead of runes to avoid unnecessary utf-8 decoding overhead:
```
goos: linux
goarch: amd64
pkg: github.com/coroot/logparser
                    │    main     │                HEAD                 │
                    │   sec/op    │   sec/op     vs base                │
ContainsTimestamp-8   56.71n ± 2%   42.36n ± 1%  -25.32% (p=0.000 n=10)
```